### PR TITLE
Fix tests for evince/papers switch, remove ODCS support and update tests

### DIFF
--- a/ci/tox.yaml
+++ b/ci/tox.yaml
@@ -5,7 +5,7 @@
         name: ensure-tox
     - name: Install all Python versions to test
       package:
-        name: ['python37', 'python38', 'python39', 'python310']
+        name: ['python3.8', 'python3.9', 'python3.10', 'python3.11', 'python3.12', 'python3.13']
         state: present
       become: yes
     - name: Run tox

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -447,7 +447,7 @@ def jobdict06():
     return {
         "assets": {
             "iso": [
-                "Fedora-ELN-20230619.1-x86_64-boot.iso"
+                "Fedora-eln-20250827.n.2-x86_64-boot.iso"
             ]
         },
         "assigned_worker_id": 78,
@@ -473,7 +473,7 @@ def jobdict06():
                 "result": "passed"
             }
         ],
-        "name": "fedora-ELN-BaseOS-boot-iso-x86_64-BuildFedora-ELN-20230619.1-install_default@uefi",
+        "name": "fedora-ELN-BaseOS-boot-iso-x86_64-BuildFedora-eln-20250827.n.2-install_default@uefi",
         "parents": {
             "Chained": [],
             "Directly chained": [],
@@ -486,18 +486,18 @@ def jobdict06():
             "ARCH": "x86_64",
             "ARCH_BASE_MACHINE": "64bit",
             "BACKEND": "qemu",
-            "BUILD": "Fedora-ELN-20230619.1",
+            "BUILD": "Fedora-eln-20250827.n.2",
             "CURRREL": "38",
             "DEPLOY_UPLOAD_TEST": "install_default_upload",
             "DISTRI": "fedora",
             "FLAVOR": "BaseOS-boot-iso",
             "IMAGETYPE": "boot",
-            "ISO": "Fedora-ELN-20230619.1-x86_64-boot.iso",
-            "ISO_URL": "https://odcs.fedoraproject.org/composes/odcs-28282/compose/BaseOS/x86_64/iso/Fedora-ELN-20230619.1-x86_64-boot.iso",
+            "ISO": "Fedora-eln-20250827.n.2-x86_64-boot.iso",
+            "ISO_URL": "https://kojipkgs.fedoraproject.org/compose/eln/Fedora-eln-20250827.n.2/compose/BaseOS/x86_64/iso/Fedora-eln-20250827.n.2-x86_64-boot.iso",
             "LABEL": "Alpha-0.1687161601",
-            "LOCATION": "https://odcs.fedoraproject.org/composes/odcs-28282/compose/",
+            "LOCATION": "https://kojipkgs.fedoraproject.org/compose/eln/Fedora-eln-20250827.n.2/compose/",
             "MACHINE": "uefi",
-            "NAME": "01982167-fedora-ELN-BaseOS-boot-iso-x86_64-BuildFedora-ELN-20230619.1-install_default@uefi",
+            "NAME": "01982167-fedora-ELN-BaseOS-boot-iso-x86_64-BuildFedora-eln-20250827.n.2-install_default@uefi",
             "NICTYPE_USER_OPTIONS": "net=172.16.2.0/24",
             "PACKAGE_SET": "default",
             "PART_TABLE_TYPE": "gpt",
@@ -562,29 +562,29 @@ def ffimg01():
 @pytest.fixture(scope="function")
 def ffimg02():
     """A pre-canned fedfind image dict, for the x86_64 BaseOS DVD from
-    Fedora-ELN-20230619.1.
+    Fedora-eln-20250827.n.2.
     """
     return {
         "variant": "BaseOS",
         "arch": "x86_64",
         "bootable": True,
         "checksums": {
-            "sha256": "d87a353dc1c68b5d6cfd381f5e68738f4435499a579020c3bb328bd27ddde0e2"
+            "sha256": "8a8396d37e9acbc7c95f4dc72e5bd1adfde71a6c569b62a598e2e5d803b0be70"
         },
         "disc_count": 1,
         "disc_number": 1,
         "format": "iso",
-        "implant_md5": "8351713601685df9bf5183792a9787ab",
-        "mtime": 1687162748,
-        "path": "BaseOS/x86_64/iso/Fedora-ELN-20230619.1-x86_64-boot.iso",
-        "size": 774379520,
+        "implant_md5": "b0626aac85ed15059b007e253b117f8b",
+        "mtime": 1756332835,
+        "path": "BaseOS/x86_64/iso/Fedora-eln-20250827.n.2-x86_64-boot.iso",
+        "size": 1088778240,
         "subvariant": "BaseOS",
         "type": "boot",
         # pylint: disable=line-too-long
-        "url": "https://odcs.fedoraproject.org/composes/odcs-28282/compose/BaseOS/x86_64/iso/Fedora-ELN-20230619.1-x86_64-boot.iso",
+        "url": "https://kojipkgs.fedoraproject.org/compose/eln/Fedora-eln-20250827.n.2/compose/BaseOS/x86_64/iso/Fedora-eln-20250827.n.2-x86_64-boot.iso",
         # pylint: disable=line-too-long
-        "direct_url": "https://odcs.fedoraproject.org/composes/odcs-28282/compose/BaseOS/x86_64/iso/Fedora-ELN-20230619.1-x86_64-boot.iso",
-        "volume_id": "Fedora-ELN-BaseOS-x86_64"
+        "direct_url": "https://kojipkgs.fedoraproject.org/compose/eln/Fedora-eln-20250827.n.2/compose/BaseOS/x86_64/iso/Fedora-eln-20250827.n.2-x86_64-boot.iso",
+        "volume_id": "Fedora-eln-BaseOS-x86_64"
     }
 
 @pytest.fixture(scope="function")
@@ -620,7 +620,7 @@ def ffmd01():
 @pytest.fixture(scope="function")
 def ffmd02():
     """Incomplete metadata dict for fedfind mocking; provides enough
-    data (on Fedora-ELN-20230619.1) to avoid round trips for
+    data (on Fedora-eln-20250827.n.2) to avoid round trips for
     compose ID purposes.
     """
     return {
@@ -631,17 +631,17 @@ def ffmd02():
             },
             "payload": {
                 "compose": {
-                    "date": "20230619",
-                    "id": "Fedora-ELN-20230619.1",
-                    "respin": 1,
-                    "type": "production"
+                    "date": "20250827",
+                    "id": "Fedora-eln-20250827.n.2",
+                    "respin": 2,
+                    "type": "nightly"
                 },
                 "release": {
                     "internal": False,
                     "name": "Fedora",
                     "short": "Fedora",
                     "type": "ga",
-                    "version": "ELN"
+                    "version": "eln"
                 },
             },
         },
@@ -655,9 +655,9 @@ def ffmock(ffmd01, ffmd02, ffimg01, ffimg02):
     the test can modify them if it wants.
     """
     mdpatch = mock.patch.object(fedfind.release.RawhideNightly, 'metadata', ffmd01)
-    mdpatch2 = mock.patch.object(fedfind.release.ElnCompose, 'metadata', ffmd02)
+    mdpatch2 = mock.patch.object(fedfind.release.ElnNightly, 'metadata', ffmd02)
     imgpatch = mock.patch.object(fedfind.release.RawhideNightly, 'all_images', [ffimg01])
-    imgpatch2 = mock.patch.object(fedfind.release.ElnCompose, 'all_images', [ffimg02])
+    imgpatch2 = mock.patch.object(fedfind.release.ElnNightly, 'all_images', [ffimg02])
     mdpatch.start()
     mdpatch2.start()
     imgpatch.start()

--- a/tests/test_consumers.py
+++ b/tests/test_consumers.py
@@ -368,38 +368,6 @@ CRITPATHEDITUC = copy.deepcopy(CRITPATHEDIT)
 CRITPATHEDITUC.body["new_builds"] = []
 CRITPATHEDITUC.body["removed_builds"] = []
 
-# ELN successful compose message. Tests should run
-ELNCOMPOSE = Message(
-    topic="org.fedoraproject.prod.odcs.compose.state-changed",
-    body={
-        "compose": {
-            "pungi_compose_id": "Fedora-ELN-20230619.1",
-            "state": 2,
-            "state_name": "done",
-            "state_reason": "Compose is generated successfully",
-            "toplevel_url": "https://odcs.fedoraproject.org/composes/odcs-28282",
-        },
-        "event": "state-changed"
-    }
-)
-
-# ELN compose message which wasn't for a state change
-ELNCOMPOSENOTSC = copy.deepcopy(ELNCOMPOSE)
-ELNCOMPOSENOTSC.body["event"] = "someotherevent"
-
-# ELN compose message where the state isn't 'done'
-ELNCOMPOSENOTDONE = copy.deepcopy(ELNCOMPOSE)
-ELNCOMPOSENOTDONE.body["compose"]["state"] = 3
-
-# ODCS compose message which isn't for ELN
-ODCSCOMPOSENOTELN = copy.deepcopy(ELNCOMPOSE)
-ODCSCOMPOSENOTELN.body["compose"]["pungi_compose_id"] = "odcs-28283-1-20230619.t.0"
-
-# ODCS compose message with the compose ID set to None - this broke
-# us in the real world, once
-ODCSCOMPOSENOCID = copy.deepcopy(ELNCOMPOSE)
-ODCSCOMPOSENOCID.body["compose"]["pungi_compose_id"] = None
-
 # Successful FCOS build message
 FCOSBUILD = Message(
     topic="org.fedoraproject.prod.coreos.build.state.change",
@@ -534,11 +502,6 @@ class TestConsumers:
             (CRITPATHEDIT, True, False, None, None),
             (CRITPATHEDITUC, False, False, None, None),
             (CRITPATHEDITUC, True, False, None, None),
-            (ELNCOMPOSE, True, None, None, None),
-            (ELNCOMPOSENOTSC, True, False, None, None),
-            (ELNCOMPOSENOTDONE, True, False, None, None),
-            (ODCSCOMPOSENOTELN, True, False, None, None),
-            (ODCSCOMPOSENOCID, True, False, None, None),
             (FCOSBUILD, False, None, None, None),
             (FCOSBUILDNOTF, False, False, None, None),
             (FCOSBUILDNOTS, False, False, None, None)

--- a/tests/test_report.py
+++ b/tests/test_report.py
@@ -97,7 +97,7 @@ def test_uniqueres_replacements(jobdict01):
     # 'app' replacements
     for (tname, expected) in (
         ("loupe", "image viewer"),
-        ("evince", "document viewer"),
+        ("papers", "document viewer"),
         ("gnome_text_editor", "text editor"),
         ("desktop_terminal", "terminal emulator"),
     ):

--- a/tests/test_report.py
+++ b/tests/test_report.py
@@ -436,7 +436,7 @@ class TestWikiReport:
         assert ret == []
 
 
-    def test_coreos_noreport(self, fake_getpassed, wikimock, oqaclientmock, jobdict06):
+    def test_eln_noreport(self, fake_getpassed, wikimock, oqaclientmock, jobdict06):
         """Check we do no reporting for Fedora ELN jobs."""
         # adjust the OpenQA_Client instance mock to return jobdict06
         instmock = oqaclientmock[1]
@@ -528,7 +528,7 @@ class TestResultsDBReport:
         instmock = oqaclientmock[1]
         instmock.get_jobs.return_value = [jobdict06]
         fosreport.resultsdb_report(jobs=[1])
-        assert fakeres.call_args[1]['item'] == "Fedora-ELN-20230619.1-x86_64-boot.iso"
+        assert fakeres.call_args[1]['item'] == "Fedora-eln-20250827.n.2-x86_64-boot.iso"
         assert fakeres.call_args[1]['ref_url'] == "https://some.url/tests/1982167"
         assert fakeres.call_args[1]['testcase']['name'] == "compose.install_default"
         assert fakeres.call_args[1]['firmware'] == "uefi"

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py38,py39,py310,py311,py312,coverage-report
+envlist = py38,py39,py310,py311,py312,py313,coverage-report
 skip_missing_interpreters = true
 isolated_build = true
 


### PR DESCRIPTION
Two test failure fixes: one overlooked test update for the switch from evince to papers, and a bigger commit to remove ODCS support now it's gone and update the tests to mock a modern ELN compose instead.