### PR TITLE
Schedule KDE-raw-xz-raw.xz on aarch64

### DIFF
--- a/src/fedora_openqa/config.py
+++ b/src/fedora_openqa/config.py
@@ -266,6 +266,14 @@ WANTED = [
             "format": "iso",
             "arch": "aarch64",
         },
+    },
+    {
+        "match": {
+            "subvariant": "KDE",
+            "type": "raw-xz",
+            "format": "raw.xz",
+            "arch": "aarch64",
+        },
     }
 ]
 

--- a/tests/test_schedule.py
+++ b/tests/test_schedule.py
@@ -324,7 +324,18 @@ class TestGetImages:
                 },
                 "Cloud_Base",
                 "qcow2"
-            )
+            ),
+            (
+                "KDE-raw_xz-raw.xz",
+                "aarch64",
+                {
+                    # pylint: disable=line-too-long
+                    "HDD_2_DECOMPRESS_URL": f"{COMPURL}Spins/aarch64/images/Fedora-KDE-{COMPVR}.aarch64.raw.xz",
+                    "TOOLBOX_IMAGE": toolboxa64
+                },
+                "KDE",
+                "raw-xz"
+            ),
         ]
 
     def test_wanted_arg(self):


### PR DESCRIPTION
We're turning on KDE aarch64 compose tests (yay), so we need to change this here.